### PR TITLE
Re-apply fixes for Mac compilation.

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -19,6 +19,8 @@
 #include <stdio.h>
 #ifdef WIN32
 #include <memory.h>
+#elif defined(__APPLE__)
+#include <malloc/malloc.h>
 #else
 #include <malloc.h>
 #endif
@@ -1925,6 +1927,8 @@ static void* crnd_default_realloc(void* p, size_t size, size_t* pActual_size, bo
     if (pActual_size) {
 #ifdef WIN32
       *pActual_size = p_new ? ::_msize(p_new) : 0;
+#elif defined(__APPLE__)
+      *pActual_size = p_new ? malloc_size(p_new) : 0;
 #else
       *pActual_size = p_new ? malloc_usable_size(p_new) : 0;
 #endif
@@ -1955,6 +1959,8 @@ static void* crnd_default_realloc(void* p, size_t size, size_t* pActual_size, bo
     if (pActual_size) {
 #ifdef WIN32
       *pActual_size = ::_msize(p_final_block);
+#elif defined(__APPLE__)
+      *pActual_size = ::malloc_size(p_final_block);
 #else
       *pActual_size = ::malloc_usable_size(p_final_block);
 #endif
@@ -1968,6 +1974,8 @@ static size_t crnd_default_msize(void* p, void* pUser_data) {
   (void)pUser_data;
 #ifdef WIN32
   return p ? _msize(p) : 0;
+#elif defined(__APPLE__)
+  return p ? malloc_size(p) : 0;
 #else
   return p ? malloc_usable_size(p) : 0;
 #endif


### PR DESCRIPTION
In Daemon these were originally done by commit fc5c77c5568bae76e6b421121d0721357ae503f9 "Port crnlib to Mac" by Amanieu. The changes were lost by switching to the Unity fork.