### PR TITLE
Improve build on FreeBSD

### DIFF
--- a/crnlib/crn_jpge.cpp
+++ b/crnlib/crn_jpge.cpp
@@ -12,7 +12,10 @@
 
 #include <stdlib.h>
 #include <string.h>
-#if defined(__APPLE__)
+#if defined(__FreeBSD__)
+// <malloc.h> has been replaced by <stdlib.h>
+#include <malloc_np.h> // for malloc_usable_size
+#elif defined(__APPLE__)
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/crnlib/crn_mem.cpp
+++ b/crnlib/crn_mem.cpp
@@ -3,7 +3,10 @@
 #include "crn_core.h"
 #include "crn_console.h"
 #include "../inc/crnlib.h"
-#if defined(__APPLE__)
+#if defined(__FreeBSD__)
+// <malloc.h> has been replaced by <stdlib.h>
+#include <malloc_np.h> // for malloc_usable_size
+#elif defined(__APPLE__)
 #include <malloc/malloc.h>
 #else
 #include <malloc.h>

--- a/crnlib/crn_threading_pthreads.cpp
+++ b/crnlib/crn_threading_pthreads.cpp
@@ -11,7 +11,7 @@
 #include "crn_winhdr.h"
 #endif
 
-#if defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/sysctl.h>
 #elif defined(__GNUC__)
 #include <sys/sysinfo.h>
@@ -29,7 +29,7 @@ void crn_threading_init() {
   SYSTEM_INFO g_system_info;
   GetSystemInfo(&g_system_info);
   g_number_of_processors = math::maximum<uint>(1U, g_system_info.dwNumberOfProcessors);
-#elif defined(__APPLE__)
+#elif defined(__FreeBSD__) || defined(__APPLE__)
   g_number_of_processors = math::maximum<int>(1, sysconf(_SC_NPROCESSORS_ONLN));
 #elif defined(__GNUC__)
   g_number_of_processors = math::maximum<int>(1, get_nprocs());

--- a/crnlib/crn_timer.cpp
+++ b/crnlib/crn_timer.cpp
@@ -4,6 +4,10 @@
 #include "crn_timer.h"
 #include <time.h>
 
+#if defined(__FreeBSD__)
+#include "sys/time.h"
+#endif
+
 #include "crn_timer.h"
 
 #if CRNLIB_USE_WIN32_API


### PR DESCRIPTION
Those commits improves the build of the `crunch` tool on FreeBSD.

Until now, only the `crnlib` was buildable on FreeBSD when integrated in another tool (for example, NetRadiant):

- https://github.com/DaemonEngine/crunch/pull/12

Now the `crunch` command line tool builds as well, if that other MR is merged:

- https://github.com/DaemonEngine/crunch/pull/38

The `crunch` tool will build but will not run properly until aligned allocation is enforced, see:

- https://github.com/DaemonEngine/crunch/pull/36

We need that other patch to avoid getting those errors at run time:

```
crunch/crnlib/crn_mem.cpp(125): Assertion failed: "crnlib_free: bad ptr"
crunch/crnlib/crn_mem.cpp(125): Assertion failed: "crnlib_realloc: bad ptr"
```

---

Original message:

This is a list of commits aiming to fix crunch build on FreeBSD. The task is not complete yet since I now face this issue and I don't know yet how to fix it:

```
[ 93%] Building CXX object crnlib/CMakeFiles/crn.dir/crn_threading_pthreads.cpp.o
…/crunch/crnlib/crn_threading_pthreads.cpp: In function 'crnlib::crn_thread_id_t crnlib::crn_get_current_thread_id()':
…/crunch/crnlib/crn_threading_pthreads.cpp:43:53: error: invalid static_cast from type 'pthread_t' {aka 'pthread*'} to type 'crnlib::crn_thread_id_t' {aka 'long long unsigned int'}
   return static_cast<crn_thread_id_t>(pthread_self());
```

about a code that is already marked as non-portable:

https://github.com/DaemonEngine/crunch/blob/98c742927514398c1bc2a81811f737a5d9905018/crnlib/crn_threading_pthreads.cpp#L37-L40

The first commit is enough to allow `crn_decomp.h` in third-party projects. I did this fix to enable crn support in [NetRadiant](https://gitlab.com/xonotic/netradiant) and `q3map2` on FreeBSD, but that would enable crn support in Dæmon engine on FreeBSD too.