### PR TITLE
FreeBSD: fix malloc in crn_decomp single header file

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -21,6 +21,9 @@
 #include <memory.h>
 #elif defined(__APPLE__)
 #include <malloc/malloc.h>
+#elif defined(__FreeBSD__)
+// <malloc.h> has been replaced by <stdlib.h>
+#include <malloc_np.h> // for malloc_usable_size
 #else
 #include <malloc.h>
 #endif


### PR DESCRIPTION
This fix is enough to enable crn decompression in third-party projects