### PR TITLE
crn_decomp: #include <stdint.h> to get uintptr_t.

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -17,6 +17,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #ifdef WIN32
 #include <memory.h>
 #elif defined(__APPLE__)


### PR DESCRIPTION
crn_decomp.h uses uintptr_t but does not #include the file defining it. Seems to compile fine with g++ on a modern machine, but fails on Xonotic's srv03 (Ubuntu LTS).

Change is hopefully safe, assuming all supported platforms actually have stdint.h. If they don't, though, why would they even know uintptr_t?