### PR TITLE
Makefile fixes to compile on srv03 and my ARM64 laptop

### DIFF
--- a/crnlib/Makefile
+++ b/crnlib/Makefile
@@ -1,11 +1,14 @@
 .DEFAULT_GOAL := all
 .PHONY: all clean
 
-COMPILE_OPTIONS = $(COMPILE_CPU_OPTIONS) $(COMPILE_DEBUG_OPTIONS) $(COMPILE_OPTIMIZATION_OPTIONS) $(COMPILE_WARN_OPTIONS)
+CXX = g++
+
 COMPILE_CPU_OPTIONS = -march=core2
 COMPILE_DEBUG_OPTIONS = -g
 COMPILE_OPTIMIZATION_OPTIONS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -fno-strict-aliasing
 COMPILE_WARN_OPTIONS = -Wall -Wno-unused-value -Wno-unused
+COMPILE_OPTIONS = $(COMPILE_CPU_OPTIONS) $(COMPILE_DEBUG_OPTIONS) $(COMPILE_OPTIMIZATION_OPTIONS) $(COMPILE_WARN_OPTIONS)
+
 LINKER_OPTIONS = -lpthread -g
 
 OBJECTS = \
@@ -86,19 +89,19 @@ OBJECTS = \
 all: crunch
 
 %.o: %.cpp
-	g++ $< -o $@ -c $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c $(COMPILE_OPTIONS)
 
 crunch.o: ../crunch/crunch.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
 
 corpus_gen.o: ../crunch/corpus_gen.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
 
 corpus_test.o: ../crunch/corpus_test.cpp
-	g++ $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
+	$(CXX) $< -o $@ -c -I../inc -I../crnlib $(COMPILE_OPTIONS)
 
 crunch: $(OBJECTS) crunch.o corpus_gen.o corpus_test.o
-	g++ $(OBJECTS) crunch.o corpus_gen.o corpus_test.o -o crunch $(LINKER_OPTIONS)
+	$(CXX) $(OBJECTS) crunch.o corpus_gen.o corpus_test.o -o crunch $(LINKER_OPTIONS)
 
 clean:
 	rm $(OBJECTS) crunch.o corpus_gen.o corpus_test.o crunch

--- a/crnlib/Makefile
+++ b/crnlib/Makefile
@@ -1,7 +1,11 @@
 .DEFAULT_GOAL := all
 .PHONY: all clean
 
-COMPILE_OPTIONS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -g -fno-strict-aliasing -Wall -Wno-unused-value -Wno-unused -march=core2
+COMPILE_OPTIONS = $(COMPILE_CPU_OPTIONS) $(COMPILE_DEBUG_OPTIONS) $(COMPILE_OPTIMIZATION_OPTIONS) $(COMPILE_WARN_OPTIONS)
+COMPILE_CPU_OPTIONS = -march=core2
+COMPILE_DEBUG_OPTIONS = -g
+COMPILE_OPTIMIZATION_OPTIONS = -O3 -fomit-frame-pointer -ffast-math -fno-math-errno -fno-strict-aliasing
+COMPILE_WARN_OPTIONS = -Wall -Wno-unused-value -Wno-unused
 LINKER_OPTIONS = -lpthread -g
 
 OBJECTS = \


### PR DESCRIPTION
No longer hardcode the compiler to be g++ (g++ on srv03 is too old, but clang++ works).

Also, split up the COMPILE_OPTIONS into separate flags so one can easily remove the -march=core2 flag (by "make COMPILE_CPU_OPTIONS="). Helps with compiling on ARM64 (binary seems to work BTW).