### PR TITLE
Fix help about `-helperThreads`, use `cCRNMaxHelperThreads`

### DIFF
--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -158,7 +158,7 @@ class crunch {
     console::printf("-dxtQuality [superfast,fast,normal,better,uber] - Endpoint optimizer speed.");
     console::printf("            Sets endpoint optimizer's max iteration depth. Default=uber.");
     console::printf("-noendpointcaching - Don't try reusing previous DXT endpoint solutions.");
-    console::printf("-grayscalsampling - Assume shader will convert fetched results to luma (Y).");
+    console::printf("-grayscalesampling - Assume shader will convert fetched results to luma (Y).");
     console::printf("-forceprimaryencoding - Only use DXT1 color4 and DXT5 alpha8 block encodings.");
     console::printf("-usetransparentindicesforblack - Try DXT1 transparent indices for dark pixels.");
 

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -89,7 +89,7 @@ class crunch {
     console::printf("-info - Only display input file statistics (no output files are written).");
 
     console::message("\nMisc. options:");
-    console::printf("-helperThreads # - Set number of helper threads, 0-16, default=(# of CPU's)-1");
+    console::printf("-helperThreads # - Set number of helper threads, 0-%d, default=(# of CPU's)-1", cCRNMaxHelperThreads);
     console::printf("-noprogress - Disable progress output");
     console::printf("-quiet - Disable all console output");
     console::printf("-ignoreerrors - Continue processing files after errors. Note: The default");


### PR DESCRIPTION
The builtin help said:

> -helperThreads # - Set number of helper threads, 0-16, default=(# of CPU's)-1

But using a number above 15 (like 16) printed:

> Warning: Value 16 for parameter "helperThreads" is out of range, clamping to 15

Since the maximum value is hardcoded as cCRNMaxHelperThreads we may even rely
on that builtin limit to always be correct.