### PR TITLE
Add `-noNormalDetection` to avoid normal map detection

### DIFF
--- a/crnlib/crn_mipmapped_texture.cpp
+++ b/crnlib/crn_mipmapped_texture.cpp
@@ -1652,7 +1652,7 @@ bool mipmapped_texture::write_ktx(data_stream_serializer& serializer) const {
 
   ktx_texture kt;
   bool success;
-  if (determine_texture_type() == cTextureTypeCubemap)
+  if (determine_texture_type(false) == cTextureTypeCubemap)
     success = kt.init_cubemap(get_width(), get_num_levels(), ogl_internal_fmt, ogl_fmt, ogl_type);
   else
     success = kt.init_2D(get_width(), get_height(), get_num_levels(), ogl_internal_fmt, ogl_fmt, ogl_type);
@@ -1767,7 +1767,7 @@ void mipmapped_texture::swap(mipmapped_texture& img) {
   CRNLIB_ASSERT(check());
 }
 
-texture_type mipmapped_texture::determine_texture_type() const {
+texture_type mipmapped_texture::determine_texture_type(bool no_normal_detection) const {
   if (!is_valid())
     return cTextureTypeUnknown;
 
@@ -1775,7 +1775,7 @@ texture_type mipmapped_texture::determine_texture_type() const {
     return cTextureTypeCubemap;
   else if (is_vertical_cross())
     return cTextureTypeVerticalCrossCubemap;
-  else if (is_normal_map())
+  else if (!no_normal_detection && is_normal_map())
     return cTextureTypeNormalMap;
 
   return cTextureTypeRegularMap;

--- a/crnlib/crn_mipmapped_texture.h
+++ b/crnlib/crn_mipmapped_texture.h
@@ -177,7 +177,7 @@ class mipmapped_texture {
   bool is_normal_map() const;
   bool is_vertical_cross() const;
   bool is_packed() const;
-  texture_type determine_texture_type() const;
+  texture_type determine_texture_type(bool no_normal_detection) const;
 
   const dynamic_string& get_last_error() const { return m_last_error; }
   void clear_last_error() { m_last_error.clear(); }

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -210,7 +210,7 @@ class crunch {
             {"blurriness", 1, false},
             {"wrap", 0, false},
             {"renormalize", 0, false},
-            { "rtopmip", 0, false },
+            {"rtopmip", 0, false },
             {"noprogress", 0, false},
             {"paramdebug", 0, false},
             {"debug", 0, false},

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -150,6 +150,7 @@ class crunch {
     console::printf(" prefer DXT1A over DXT5 for images with alpha channels (.DDS only).");
     console::printf("-uniformMetrics - Use uniform color metrics, default=use perceptual metrics");
     console::printf("-noAdaptiveBlocks - Disable adaptive block sizes (i.e. disable macroblocks).");
+    console::printf("-noNormalDetection - Disable normal map detection, default=disabled");
 #ifdef CRNLIB_SUPPORT_ATI_COMPRESS
     console::printf("-compressor [CRN,CRNF,RYG,ATI] - Set DXTn compressor, default=CRN");
 #else
@@ -221,6 +222,7 @@ class crunch {
             {"alphaThreshold", 1, false},
             {"uniformMetrics", 0, false},
             {"noAdaptiveBlocks", 0, false},
+            {"noNormalDetection", 0, false},
             {"compressor", 1, false},
             {"dxtQuality", 1, false},
             {"noendpointcaching", 0, false},
@@ -918,13 +920,16 @@ class crunch {
         compressed_size = cmp_tex_bytes.size();
       }
     }
+
+    bool no_normal_type = m_params.has_key("noNormalDetection");
+
     console::info("Source texture dimensions: %ux%u, Levels: %u, Faces: %u, Format: %s\nPacked Format: %u, Apparent Type: %s, Flipped: %u, Can Unflip Without Unpacking: %u",
                   src_tex.get_width(),
                   src_tex.get_height(),
                   src_tex.get_num_levels(),
                   src_tex.get_num_faces(),
                   pixel_format_helpers::get_pixel_format_string(src_tex.get_format()),
-                  src_tex.is_packed(), get_texture_type_desc(src_tex.determine_texture_type()),
+                  src_tex.is_packed(), get_texture_type_desc(src_tex.determine_texture_type(no_normal_type)),
                   src_tex.is_flipped(), src_tex.can_unflip_without_unpacking());
 
     console::info("Total pixels: %u, Source file size: " CRNLIB_UINT64_FORMAT_SPECIFIER ", Source file bits/pixel: %1.3f",
@@ -1039,7 +1044,9 @@ class crunch {
 
     texture_conversion::convert_params params;
 
-    params.m_texture_type = src_tex.determine_texture_type();
+    bool no_normal_type = m_params.has_key("noNormalDetection");
+    params.m_texture_type = src_tex.determine_texture_type(no_normal_type);
+
     params.m_pInput_texture = &src_tex;
     params.m_dst_filename = pDst_filename;
     params.m_dst_file_type = out_file_type;


### PR DESCRIPTION
Add `-noNormalDetection` to avoid normal map detection

Crunch has an algorithm to try to detect normal maps, probably to pick higher quality compressors.

It prevents the compressor to wrongly detect a normal map and select formats like `DXT5_AGBR` when `DXT1` is good enough.

It does not only avoid to produce files in less supported swizzled formats, it also allows to pick smaller formats, sometime saving half of the produced file size.