### PR TITLE
crunch: add -h option to print help

### DIFF
--- a/crnlib/crn_command_line_params.cpp
+++ b/crnlib/crn_command_line_params.cpp
@@ -140,6 +140,15 @@ bool command_line_params::parse(const dynamic_string_array& params, uint n, cons
 
       key_str.right(1);
 
+#if CRNLIB_CMD_LINE_ALLOW_SLASH_PARAMS
+      if ((src_param == "/?") || (src_param == "--help"))
+#else
+      if (src_param == "--help")
+#endif
+      {
+        key_str.set("h");
+      }
+
       int modifier = 0;
       char c = key_str[key_str.get_len() - 1];
       if (c == '+')

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -73,6 +73,8 @@ class crunch {
     console::printf("See the docs for stb_image.c: http://www.nothings.org/stb_image.c");
     console::printf("Progressive JPEG files are supported, see: http://code.google.com/p/jpeg-compressor/");
 
+    console::printf("\n-h - Print this help.");
+
     console::message("\nPath/file related parameters:");
     console::printf("-out filename - Output filename");
     console::printf("-outdir dir - Output directory");
@@ -182,6 +184,8 @@ class crunch {
 
     command_line_params::param_desc std_params[] =
         {
+            {"h", 0, false},
+
             {"file", 1, true},
 
             {"out", 1, false},
@@ -293,6 +297,12 @@ class crunch {
          return false;
       }
 #endif
+
+    if (m_params.get_value_as_bool("h")) {
+      print_usage();
+
+      return true;
+    }
 
     if (m_params.get_value_as_bool("debug")) {
       console::debug("Command line parameters:");


### PR DESCRIPTION
My routine to get help was:

```
$ crunch -h
Error: Unrecognized command line parameter: "-h"
Exit status: 1

$ crunch --help
Error: Unrecognized command line parameter: "--help"
Exit status: 1

$ crunch
Error: No command line parameters specified!

Command line usage:
[…]
Exit status: 1
```

Now I can do:

```
$ crunch -h
Command line usage:
[…]
Exit status: 0
```

Long options `--help` is also available, and `/?` is available on Windows as well.