### PR TITLE
Bump m_userdata0 to 1 to produce files openable with latest Unity game engine

### DIFF
--- a/inc/crnlib.h
+++ b/inc/crnlib.h
@@ -226,7 +226,7 @@ struct crn_comp_params {
     m_crn_alpha_selector_palette_size = 0;
 
     m_num_helper_threads = 0;
-    m_userdata0 = 0;
+    m_userdata0 = 1;
     m_userdata1 = 0;
     m_pProgress_func = NULL;
     m_pProgress_func_data = NULL;


### PR DESCRIPTION
According to the Unity forums the Unity game engine now expects m_userdata0 value to be 1 for files produced by this tool with this format to be loaded.

See https://forum.unity.com/threads/crunch-textures.522787/#post-4282222 

This is very likely to recognize files produced by the now-incompatible old crunch tool.

At some point we may print a warning when reading files using the 0 value. This would allow softwares like the Dæmon game engine to inform the user that maybe the file is not compatible because it may have been produced with an incompatible tool.

At some point we may even add an optional mechanism to not load files using the 0 value for software that will never have to read CRN files using new Unity format but with old number m_userdata0 0.

For example, once we would have entirely rebuilt Unvanquished game data and community maps with CRN files using the m_userdata 1 field and are confident there is no files to be used with new format but old value, we could prevent the loading of files using the old value in Dæmon game engine and tools like the NetRadiant game level editor or the Q3map2 map compiler.

See issue https://github.com/DaemonEngine/crunch/issues/32