### PR TITLE
crunch: use `_FILE_OFFSET_BITS 64` with `fopen`/`fseek`/`ftell` outside of Linux

### DIFF
--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -18,10 +18,16 @@ const bool c_crnlib_little_endian_platform = false;
 
 const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 
-#if defined(__GNUC__) && !defined(__APPLE__)
+#if defined(__linux__)
 #define crn_fopen(pDstFile, f, m) *(pDstFile) = fopen64(f, m)
 #define crn_fseek fseeko64
 #define crn_ftell ftello64
+#elif defined(__GNUC__)
+// This should be defined before including any header.
+#define _FILE_OFFSET_BITS 64
+#define crn_fopen(pDstFile, f, m) *(pDstFile) = fopen(f, m)
+#define crn_fseek fseeko
+#define crn_ftell ftello
 #elif defined(_MSC_VER)
 #define crn_fopen(pDstFile, f, m) fopen_s(pDstFile, f, m)
 #define crn_fseek _fseeki64


### PR DESCRIPTION
crunch: use `_FILE_OFFSET_BITS 64` with `fopen`/`fseek`/`ftell` outside of Linux.

It seems to work on macOS and FreeBSD without requiring specific `#ifdef` for any them. It also works on Linux but
we may still prefer `*64` variants to avoid ambiguity.

_Note_: If needed, `minizip/ioapi.h` is known to provide more compatibility code for old MSVC too, but what we have looks good enough on that part.