### PR TITLE
Allow validating the header without CRCing the entire file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,15 @@ option(BUILD_SHARED_LIBCRN "Build shared libcrn" OFF)
 option(BUILD_STATIC_LIBCRN "Build static libcrn" OFF)
 option(BUILD_CRUNCH "Build crunch" ON)
 option(BUILD_EXAMPLES "Build examples" OFF)
-option(OPTIMIZE_RELEASE "Optimize release build" ON)
+if (NOT MSVC)
+  option(OPTIMIZE_RELEASE "Optimize release build" ON)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-value -Wno-unused")
+if (NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-value -Wno-unused")
+endif()
 
 if(OPTIMIZE_RELEASE)
   # CMake already sets -O3 flag on release build

--- a/inc/crn_defs.h
+++ b/inc/crn_defs.h
@@ -113,7 +113,14 @@ uint32 crnd_get_crn_format_bits_per_texel(crn_format fmt);
 // Returns the number of bytes per DXTn block (8 or 16).
 uint32 crnd_get_bytes_per_dxt_block(crn_format fmt);
 
-// Validates the entire file by checking the header and data CRC's.
+// Validates the file header, performing a CRC check on it and verifying that there is
+// e.g. a sane number of levels.
+// pData/data_size need only include the header, but may be the whole file.
+// The crn_file_info.m_struct_size field must be set before calling this function.
+bool crnd_validate_header(const void* pData, uint32 data_size, crn_file_info* pFile_info);
+
+// Validates the entire file by calling crnd_validate_header, then checking the data CRC
+// for the whole file.
 // This is not something you want to be doing much!
 // The crn_file_info.m_struct_size field must be set before calling this function.
 bool crnd_validate_file(const void* pData, uint32 data_size, crn_file_info* pFile_info);


### PR DESCRIPTION
The CRC implementation is slow and who cares if 1 pixel is wrong?