### PR TITLE
Improve MinGW compatibility

### DIFF
--- a/cmake/cross-toolchain-mingw32.cmake
+++ b/cmake/cross-toolchain-mingw32.cmake
@@ -1,0 +1,16 @@
+# Target operating system and architecture
+set( CMAKE_SYSTEM_NAME Windows )
+set( CMAKE_SYSTEM_PROCESSOR x86 )
+
+# C/C++ compilers
+set( CMAKE_C_COMPILER i686-w64-mingw32-gcc )
+set( CMAKE_CXX_COMPILER i686-w64-mingw32-g++ )
+set( CMAKE_RC_COMPILER i686-w64-mingw32-windres )
+
+# Target prefix
+set( CMAKE_FIND_ROOT_PATH /usr/i686-w64-mingw32 )
+
+# Find programs using host paths and headers/libraries using target paths
+set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )

--- a/cmake/cross-toolchain-mingw64.cmake
+++ b/cmake/cross-toolchain-mingw64.cmake
@@ -1,0 +1,16 @@
+# Target operating system and architecture
+set( CMAKE_SYSTEM_NAME Windows )
+set( CMAKE_SYSTEM_PROCESSOR x86_64 )
+
+# C/C++ compilers
+set( CMAKE_C_COMPILER x86_64-w64-mingw32-gcc )
+set( CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++ )
+set( CMAKE_RC_COMPILER x86_64-w64-mingw32-windres )
+
+# Target prefix
+set( CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32 )
+
+# Find programs using host paths and headers/libraries using target paths
+set( CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER )
+set( CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY )
+set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY )

--- a/crnlib/crn_arealist.cpp
+++ b/crnlib/crn_arealist.cpp
@@ -13,8 +13,8 @@ static void area_fatal_error(const char*, const char* pMsg, ...) {
   va_start(args, pMsg);
 
   char buf[512];
-#ifdef _MSC_VER
-  _vsnprintf_s(buf, sizeof(buf), pMsg, args);
+#if defined(_WIN32)
+  vsnprintf_s(buf, sizeof(buf), pMsg, args);
 #else
   vsnprintf(buf, sizeof(buf), pMsg, args);
 #endif

--- a/crnlib/crn_dynamic_string.cpp
+++ b/crnlib/crn_dynamic_string.cpp
@@ -236,7 +236,7 @@ dynamic_string& dynamic_string::truncate(uint new_len) {
 
 dynamic_string& dynamic_string::tolower() {
   if (m_len) {
-#ifdef _MSC_VER
+#if defined(_WIN32)
     _strlwr_s(get_ptr_priv(), m_buf_size);
 #else
     strlwr(get_ptr_priv());
@@ -247,7 +247,7 @@ dynamic_string& dynamic_string::tolower() {
 
 dynamic_string& dynamic_string::toupper() {
   if (m_len) {
-#ifdef _MSC_VER
+#if defined(_WIN32)
     _strupr_s(get_ptr_priv(), m_buf_size);
 #else
     strupr(get_ptr_priv());
@@ -300,7 +300,7 @@ dynamic_string& dynamic_string::format_args(const char* p, va_list args) {
   const uint cBufSize = 4096;
   char buf[cBufSize];
 
-#ifdef _MSC_VER
+#if defined(_WIN32)
   int l = vsnprintf_s(buf, cBufSize, _TRUNCATE, p, args);
 #else
   int l = vsnprintf(buf, cBufSize, p, args);

--- a/crnlib/crn_platform.cpp
+++ b/crnlib/crn_platform.cpp
@@ -5,7 +5,8 @@
 #if CRNLIB_USE_WIN32_API
 #include "crn_winhdr.h"
 #endif
-#ifndef _MSC_VER
+
+#if !defined(_WIN32)
 int sprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, ...) {
   if (!sizeOfBuffer)
     return 0;
@@ -54,7 +55,7 @@ char* strupr(char* p) {
   }
   return p;
 }
-#endif  // __GNUC__
+#endif
 
 void crnlib_debug_break(void) {
   CRNLIB_BREAKPOINT

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -18,7 +18,11 @@ const bool c_crnlib_little_endian_platform = false;
 
 const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 
-#if defined(__linux__)
+#if defined(_WIN32)
+#define crn_fopen(pDstFile, f, m) fopen_s(pDstFile, f, m)
+#define crn_fseek _fseeki64
+#define crn_ftell _ftelli64
+#elif defined(__linux__)
 #define crn_fopen(pDstFile, f, m) *(pDstFile) = fopen64(f, m)
 #define crn_fseek fseeko64
 #define crn_ftell ftello64
@@ -28,10 +32,6 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 #define crn_fopen(pDstFile, f, m) *(pDstFile) = fopen(f, m)
 #define crn_fseek fseeko
 #define crn_ftell ftello
-#elif defined(_MSC_VER)
-#define crn_fopen(pDstFile, f, m) fopen_s(pDstFile, f, m)
-#define crn_fseek _fseeki64
-#define crn_ftell _ftelli64
 #else
 #define crn_fopen(pDstFile, f, m) *(pDstFile) = fopen(f, m)
 #define crn_fseek(s, o, w) fseek(s, static_cast<long>(o), w)

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -66,7 +66,7 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 
 #define CRNLIB_GET_ALIGNMENT(v) ((!sizeof(v)) ? 1 : (__alignof(v) ? __alignof(v) : sizeof(uint32)))
 
-#ifndef _MSC_VER
+#if !defined(_WIN32)
 int sprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, ...);
 int vsprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, va_list args);
 char* strlwr(char* p);

--- a/crnlib/crn_vector.cpp
+++ b/crnlib/crn_vector.cpp
@@ -34,7 +34,7 @@ bool elemental_vector::increase_capacity(uint min_new_capacity, bool grow_hint, 
         return false;
 
       char buf[256];
-#ifdef _MSC_VER
+#if defined(_WIN32)
       sprintf_s(buf, sizeof(buf), "vector: crnlib_realloc() failed allocating %u bytes", (uint)desired_size);
 #else
       snprintf(buf, sizeof(buf), "vector: crnlib_realloc() failed allocating %u bytes", (uint)desired_size);
@@ -49,7 +49,7 @@ bool elemental_vector::increase_capacity(uint min_new_capacity, bool grow_hint, 
         return false;
 
       char buf[256];
-#ifdef _MSC_VER
+#if defined(_WIN32)
       sprintf_s(buf, sizeof(buf), "vector: crnlib_malloc() failed allocating %u bytes", (uint)desired_size);
 #else
       snprintf(buf, sizeof(buf), "vector: crnlib_malloc() failed allocating %u bytes", (uint)desired_size);

--- a/crnlib/lzma_Types.h
+++ b/crnlib/lzma_Types.h
@@ -90,9 +90,9 @@ typedef int Bool;
 #define True 1
 #define False 0
 
-#ifdef _MSC_VER
+#if defined(_WIN32)
 
-#if _MSC_VER >= 1300
+#if defined(_MSC_VER) && _MSC_VER >= 1300
 #define MY_NO_INLINE __declspec(noinline)
 #else
 #define MY_NO_INLINE

--- a/example2/example2.cpp
+++ b/example2/example2.cpp
@@ -8,6 +8,7 @@
 // See Copyright Notice and license at the end of inc/crnlib.h
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <math.h>
 #include <algorithm>
 

--- a/example3/example3.cpp
+++ b/example3/example3.cpp
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include <minmax.h>
+#include <algorithm>
 
 // CRN transcoder library.
 #include "crnlib.h"
@@ -195,9 +195,9 @@ int main(int argc, char* argv[]) {
       // Exact block from image, clamping at the sides of non-divisible by 4 images to avoid artifacts.
       crn_uint32* pDst_pixels = pixels;
       for (int y = 0; y < cDXTBlockSize; y++) {
-        const uint actual_y = min(height - 1U, (block_y * cDXTBlockSize) + y);
+        const uint actual_y = std::min(height - 1U, (block_y * cDXTBlockSize) + y);
         for (int x = 0; x < cDXTBlockSize; x++) {
-          const uint actual_x = min(width - 1U, (block_x * cDXTBlockSize) + x);
+          const uint actual_x = std::min(width - 1U, (block_x * cDXTBlockSize) + x);
           *pDst_pixels++ = pSrc_image[actual_x + actual_y * width];
         }
       }

--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -1599,7 +1599,7 @@ namespace crnd {
 void crnd_assert(const char* pExp, const char* pFile, unsigned line) {
   char buf[512];
 
-#if defined(WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
   sprintf_s(buf, sizeof(buf), "%s(%u): Assertion failure: \"%s\"\n", pFile, line, pExp);
 #else
   snprintf(buf, sizeof(buf), "%s(%u): Assertion failure: \"%s\"\n", pFile, line, pExp);
@@ -1616,7 +1616,7 @@ void crnd_assert(const char* pExp, const char* pFile, unsigned line) {
 void crnd_trace(const char* pFmt, va_list args) {
   if (crnd_is_debugger_present()) {
     char buf[512];
-#if defined(WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
     vsprintf_s(buf, sizeof(buf), pFmt, args);
 #else
     vsnprintf(buf, sizeof(buf), pFmt, args);


### PR DESCRIPTION
- Provide ready-to-use cmake toolchain file for MinGW,
- Fix build on 32-bit MinGW,
- Avoid a warning by not redefining Win32 functions on MinGW,
- Use more Win32 code with MinGW.