### PR TITLE
Factorize the system-specific function shims like snprintf

### DIFF
--- a/crnlib/crn_arealist.cpp
+++ b/crnlib/crn_arealist.cpp
@@ -13,11 +13,7 @@ static void area_fatal_error(const char*, const char* pMsg, ...) {
   va_start(args, pMsg);
 
   char buf[512];
-#if defined(_WIN32)
-  vsnprintf_s(buf, sizeof(buf), pMsg, args);
-#else
-  vsnprintf(buf, sizeof(buf), pMsg, args);
-#endif
+  crnlib_vsnprintf(buf, sizeof(buf), pMsg, args);
 
   va_end(args);
 

--- a/crnlib/crn_assert.cpp
+++ b/crnlib/crn_assert.cpp
@@ -15,7 +15,7 @@ void crnlib_enable_fail_exceptions(bool enabled) {
 void crnlib_assert(const char* pExp, const char* pFile, unsigned line) {
   char buf[512];
 
-  sprintf_s(buf, sizeof(buf), "%s(%u): Assertion failed: \"%s\"\n", pFile, line, pExp);
+  crnlib_snprintf(buf, sizeof(buf), "%s(%u): Assertion failed: \"%s\"\n", pFile, line, pExp);
 
   crnlib_output_debug_string(buf);
 
@@ -28,7 +28,7 @@ void crnlib_assert(const char* pExp, const char* pFile, unsigned line) {
 void crnlib_fail(const char* pExp, const char* pFile, unsigned line) {
   char buf[512];
 
-  sprintf_s(buf, sizeof(buf), "%s(%u): Failure: \"%s\"\n", pFile, line, pExp);
+  crnlib_snprintf(buf, sizeof(buf), "%s(%u): Failure: \"%s\"\n", pFile, line, pExp);
 
   crnlib_output_debug_string(buf);
 
@@ -49,7 +49,7 @@ void crnlib_fail(const char* pExp, const char* pFile, unsigned line) {
 void trace(const char* pFmt, va_list args) {
   if (crnlib_is_debugger_present()) {
     char buf[512];
-    vsprintf_s(buf, sizeof(buf), pFmt, args);
+    crnlib_snprintf(buf, sizeof(buf), pFmt, args);
 
     crnlib_output_debug_string(buf);
   }

--- a/crnlib/crn_console.cpp
+++ b/crnlib/crn_console.cpp
@@ -51,7 +51,7 @@ void console::vprintf(eConsoleMessageType type, const char* p, va_list args) {
   m_num_messages[type]++;
 
   char buf[cConsoleBufSize];
-  vsprintf_s(buf, cConsoleBufSize, p, args);
+  crnlib_vsnprintf(buf, cConsoleBufSize, p, args);
 
   bool handled = false;
 

--- a/crnlib/crn_dynamic_string.cpp
+++ b/crnlib/crn_dynamic_string.cpp
@@ -236,22 +236,14 @@ dynamic_string& dynamic_string::truncate(uint new_len) {
 
 dynamic_string& dynamic_string::tolower() {
   if (m_len) {
-#if defined(_WIN32)
-    _strlwr_s(get_ptr_priv(), m_buf_size);
-#else
-    strlwr(get_ptr_priv());
-#endif
+    crnlib_strnlwr(get_ptr_priv(), m_buf_size);
   }
   return *this;
 }
 
 dynamic_string& dynamic_string::toupper() {
   if (m_len) {
-#if defined(_WIN32)
-    _strupr_s(get_ptr_priv(), m_buf_size);
-#else
-    strupr(get_ptr_priv());
-#endif
+    crnlib_strnupr(get_ptr_priv(), m_buf_size);
   }
   return *this;
 }

--- a/crnlib/crn_dynamic_string.cpp
+++ b/crnlib/crn_dynamic_string.cpp
@@ -303,7 +303,7 @@ dynamic_string& dynamic_string::format_args(const char* p, va_list args) {
 #if defined(_WIN32)
   int l = vsnprintf_s(buf, cBufSize, _TRUNCATE, p, args);
 #else
-  int l = vsnprintf(buf, cBufSize, p, args);
+  int l = crnlib_vsnprintf(buf, cBufSize, p, args);
 #endif
   if (l <= 0)
     clear();

--- a/crnlib/crn_dynamic_string.cpp
+++ b/crnlib/crn_dynamic_string.cpp
@@ -71,7 +71,7 @@ void dynamic_string::optimize() {
 int dynamic_string::compare(const char* p, bool case_sensitive) const {
   CRNLIB_ASSERT(p);
 
-  const int result = (case_sensitive ? strcmp : crn_stricmp)(get_ptr_priv(), p);
+  const int result = (case_sensitive ? strcmp : crnlib_stricmp)(get_ptr_priv(), p);
 
   if (result < 0)
     return -1;
@@ -379,7 +379,7 @@ int dynamic_string::find_left(const char* p, bool case_sensitive) const {
   const int p_len = (int)strlen(p);
 
   for (int i = 0; i <= (m_len - p_len); i++)
-    if ((case_sensitive ? strncmp : _strnicmp)(p, &m_pStr[i], p_len) == 0)
+    if ((case_sensitive ? strncmp : crnlib_strnicmp)(p, &m_pStr[i], p_len) == 0)
       return i;
 
   return -1;
@@ -416,7 +416,7 @@ int dynamic_string::find_right(const char* p, bool case_sensitive) const {
   const int p_len = (int)strlen(p);
 
   for (int i = m_len - p_len; i >= 0; i--)
-    if ((case_sensitive ? strncmp : _strnicmp)(p, &m_pStr[i], p_len) == 0)
+    if ((case_sensitive ? strncmp : crnlib_strnicmp)(p, &m_pStr[i], p_len) == 0)
       return i;
 
   return -1;

--- a/crnlib/crn_platform.cpp
+++ b/crnlib/crn_platform.cpp
@@ -7,37 +7,6 @@
 #endif
 
 #if !defined(_WIN32)
-int sprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, ...) {
-  if (!sizeOfBuffer)
-    return 0;
-
-  va_list args;
-  va_start(args, format);
-  int c = vsnprintf(buffer, sizeOfBuffer, format, args);
-  va_end(args);
-
-  buffer[sizeOfBuffer - 1] = '\0';
-
-  if (c < 0)
-    return sizeOfBuffer - 1;
-
-  return CRNLIB_MIN(c, (int)sizeOfBuffer - 1);
-}
-
-int vsprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, va_list args) {
-  if (!sizeOfBuffer)
-    return 0;
-
-  int c = vsnprintf(buffer, sizeOfBuffer, format, args);
-
-  buffer[sizeOfBuffer - 1] = '\0';
-
-  if (c < 0)
-    return sizeOfBuffer - 1;
-
-  return CRNLIB_MIN(c, (int)sizeOfBuffer - 1);
-}
-
 char* strlwr(char* p) {
   char* q = p;
   while (*q) {

--- a/crnlib/crn_platform.cpp
+++ b/crnlib/crn_platform.cpp
@@ -7,18 +7,18 @@
 #endif
 
 #if !defined(_WIN32)
-char* strlwr(char* p) {
+char* crnlib_strnlwr(char* p, size_t n) {
   char* q = p;
-  while (*q) {
+  for (size_t i = 0; i < n && *q; i++) {
     char c = *q;
     *q++ = tolower(c);
   }
   return p;
 }
 
-char* strupr(char* p) {
+char* crnlib_strnupr(char* p, size_t n) {
   char* q = p;
-  while (*q) {
+  for (size_t i = 0; i < n && *q; i++) {
     char c = *q;
     *q++ = toupper(c);
   }

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -69,23 +69,15 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 #if defined(_WIN32)
 #define crnlib_snprintf sprintf_s
 #define crnlib_vsnprintf vsprintf_s
-#else
-#define crnlib_snprintf snprintf
-#define crnlib_vsnprintf vsnprintf
-#endif
-
-#if defined(_WIN32)
 #define crnlib_strnlwr _strlwr_s
 #define crnlib_strnupr _strupr_s
-#else
-char* crnlib_strnlwr(char* p, size_t n);
-char* crnlib_strnupr(char* p, size_t n);
-#endif
-
-#if defined(_WIN32)
 #define crnlib_stricmp _stricmp
 #define crnlib_strnicmp _strnicmp
 #else
+#define crnlib_snprintf snprintf
+#define crnlib_vsnprintf vsnprintf
+char* crnlib_strnlwr(char* p, size_t n);
+char* crnlib_strnupr(char* p, size_t n);
 #define crnlib_stricmp strcasecmp
 #define crnlib_strnicmp strncasecmp
 #endif

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -74,9 +74,15 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 #define crnlib_vsnprintf vsnprintf
 #endif
 
+#if defined(_WIN32)
+#define crnlib_strnlwr _strlwr_s
+#define crnlib_strnupr _strupr_s
+#else
+char* crnlib_strnlwr(char* p, size_t n);
+char* crnlib_strnupr(char* p, size_t n);
+#endif
+
 #if !defined(_WIN32)
-char* strlwr(char* p);
-char* strupr(char* p);
 #define _stricmp strcasecmp
 #define _strnicmp strncasecmp
 #endif

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -66,9 +66,15 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
 
 #define CRNLIB_GET_ALIGNMENT(v) ((!sizeof(v)) ? 1 : (__alignof(v) ? __alignof(v) : sizeof(uint32)))
 
+#if defined(_WIN32)
+#define crnlib_snprintf sprintf_s
+#define crnlib_vsnprintf vsprintf_s
+#else
+#define crnlib_snprintf snprintf
+#define crnlib_vsnprintf vsnprintf
+#endif
+
 #if !defined(_WIN32)
-int sprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, ...);
-int vsprintf_s(char* buffer, size_t sizeOfBuffer, const char* format, va_list args);
 char* strlwr(char* p);
 char* strupr(char* p);
 #define _stricmp strcasecmp

--- a/crnlib/crn_platform.h
+++ b/crnlib/crn_platform.h
@@ -82,9 +82,12 @@ char* crnlib_strnlwr(char* p, size_t n);
 char* crnlib_strnupr(char* p, size_t n);
 #endif
 
-#if !defined(_WIN32)
-#define _stricmp strcasecmp
-#define _strnicmp strncasecmp
+#if defined(_WIN32)
+#define crnlib_stricmp _stricmp
+#define crnlib_strnicmp _strnicmp
+#else
+#define crnlib_stricmp strcasecmp
+#define crnlib_strnicmp strncasecmp
 #endif
 
 inline bool crnlib_is_little_endian() {

--- a/crnlib/crn_resample_filters.cpp
+++ b/crnlib/crn_resample_filters.cpp
@@ -296,7 +296,7 @@ const int g_num_resample_filters = sizeof(g_resample_filters) / sizeof(g_resampl
 
 int find_resample_filter(const char* pName) {
   for (int i = 0; i < g_num_resample_filters; i++)
-    if (_stricmp(pName, g_resample_filters[i].name) == 0)
+    if (crnlib_stricmp(pName, g_resample_filters[i].name) == 0)
       return i;
   return cInvalidIndex;
 }

--- a/crnlib/crn_strutils.cpp
+++ b/crnlib/crn_strutils.cpp
@@ -16,10 +16,6 @@ char* crn_strdup(const char* pStr) {
   return p;
 }
 
-int crn_stricmp(const char* p, const char* q) {
-  return _stricmp(p, q);
-}
-
 char* strcpy_safe(char* pDst, uint dst_len, const char* pSrc) {
   CRNLIB_ASSERT(pDst && pSrc && dst_len);
   if (!dst_len)
@@ -310,10 +306,10 @@ bool string_to_bool(const char* p, bool& value) {
 
   value = false;
 
-  if (_stricmp(p, "false") == 0)
+  if (crnlib_stricmp(p, "false") == 0)
     return true;
 
-  if (_stricmp(p, "true") == 0) {
+  if (crnlib_stricmp(p, "true") == 0) {
     value = true;
     return true;
   }

--- a/crnlib/crn_strutils.h
+++ b/crnlib/crn_strutils.h
@@ -10,7 +10,6 @@
 
 namespace crnlib {
 char* crn_strdup(const char* pStr);
-int crn_stricmp(const char* p, const char* q);
 
 char* strcpy_safe(char* pDst, uint dst_len, const char* pSrc);
 

--- a/crnlib/crn_value.h
+++ b/crnlib/crn_value.h
@@ -166,10 +166,10 @@ class value {
       return false;
     }
 
-    if (_stricmp(p, "false") == 0) {
+    if (crnlib_stricmp(p, "false") == 0) {
       set_bool(false);
       return true;
-    } else if (_stricmp(p, "true") == 0) {
+    } else if (crnlib_stricmp(p, "true") == 0) {
       set_bool(true);
       return true;
     }

--- a/crnlib/lzham_timer.h
+++ b/crnlib/lzham_timer.h
@@ -62,7 +62,7 @@ class scoped_perf_section {
       : m_start_ticks(lzham_timer::get_ticks()) {
     va_list args;
     va_start(args, pName);
-    vsprintf_s(m_name, sizeof(m_name), pName, args);
+    crnlib_vsnprintf(m_name, sizeof(m_name), pName, args);
     va_end(args);
 
     lzham_buffered_printf("Thread: 0x%08X, BEGIN Time: %3.3fms, Section: %s\n", GetCurrentThreadId(), lzham_timer::ticks_to_ms(m_start_ticks), m_name);

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -1137,7 +1137,7 @@ class crunch {
 static bool check_for_option(int argc, char* argv[], const char* pOption) {
   for (int i = 1; i < argc; i++) {
     if ((argv[i][0] == '/') || (argv[i][0] == '-')) {
-      if (crn_stricmp(&argv[i][1], pOption) == 0)
+      if (crnlib_stricmp(&argv[i][1], pOption) == 0)
         return true;
     }
   }

--- a/example2/example2.cpp
+++ b/example2/example2.cpp
@@ -20,6 +20,8 @@
 // A simple high-precision, platform independent timer class.
 #include "timer.h"
 
+#include "crn_platform.h"
+
 using namespace crnlib;
 
 static int print_usage() {
@@ -35,7 +37,7 @@ static int error(const char* pMsg, ...) {
   va_list args;
   va_start(args, pMsg);
   char buf[512];
-  vsprintf_s(buf, sizeof(buf), pMsg, args);
+  crnlib_vsnprintf(buf, sizeof(buf), pMsg, args);
   va_end(args);
   printf("%s", buf);
   return EXIT_FAILURE;
@@ -46,7 +48,7 @@ static crn_uint8* read_file_into_buffer(const char* pFilename, crn_uint32& size)
   size = 0;
 
   FILE* pFile = NULL;
-  fopen_s(&pFile, pFilename, "rb");
+  crn_fopen(&pFile, pFilename, "rb");
   if (!pFile)
     return NULL;
 
@@ -80,7 +82,7 @@ int main(int argc, char* argv[]) {
     if (argv[i][0] == '/')
       argv[i][0] = '-';
 
-    if (!_stricmp(argv[i], "-out")) {
+    if (!crnlib_stricmp(argv[i], "-out")) {
       if (++i >= argc)
         return error("Expected output filename!");
 
@@ -131,13 +133,14 @@ int main(int argc, char* argv[]) {
 
   // Now create the DDS file.
   char dst_filename[FILENAME_MAX];
-  sprintf_s(dst_filename, sizeof(dst_filename), "%s%s%s.dds", drive_buf, dir_buf, fname_buf);
+  crnlib_snprintf(dst_filename, sizeof(dst_filename), "%s%s%s.dds", drive_buf, dir_buf, fname_buf);
   if (out_filename[0])
     strcpy(dst_filename, out_filename);
 
   printf("Writing DDS file: %s\n", dst_filename);
 
-  FILE* pDDS_file = fopen(dst_filename, "wb");
+  FILE* pDDS_file = NULL;
+  crn_fopen(&pDDS_file, dst_filename, "wb");
   if (!pDDS_file) {
     crnd::crnd_unpack_end(pContext);
     free(pSrc_file_data);


### PR DESCRIPTION
- do not reuse Windows name as alias on non-Windows system,
- do not re-implement functions there is a system implementation for,
- deduplicate implementations for things like `stricmp`,
- avoid doing `ifdef` everywhere.