### PR TITLE
crnlib: do not call `sem_destroy` on macOS

### DIFF
--- a/crnlib/crn_threading_pthreads.cpp
+++ b/crnlib/crn_threading_pthreads.cpp
@@ -125,8 +125,9 @@ semaphore::semaphore(long initialCount, long maximumCount, const char* pName) {
 }
 
 semaphore::~semaphore() {
+#if !defined(__APPLE__)
   sem_destroy(m_sem);
-#if defined(__APPLE__)
+#else
   sem_unlink(m_name);
 #endif
 }


### PR DESCRIPTION
On macOS, `sem_unlink` should be used instead of `sem_destroy`, what the current code does is to call `sem_destroy` on every pthread-compatible system and then call `sem_unlink` on macOS.

It is expected the only macOS implementation of it and other functions like `sem_init` is to do nothing but to exist and be marked as deprecated so the compiler can print warnings as the `-Wdeprecated-declarations` flag is enabled by default.

Because `sem_destroy` is expected to be a stub on macOS and we call `sem_unlink anyway`, the current code works but raises a “'sem_destroy' is deprecated” warning at build time for something we don't need and  we already have the right implementation done anyway.