### PR TITLE
Add `-noTitle` option to avoid printing the title on every run (makes output less noisy)

### DIFF
--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -215,7 +215,6 @@ class crunch {
             {"wrap", 0, false},
             {"renormalize", 0, false},
             {"rtopmip", 0, false },
-            {"noprogress", 0, false},
             {"paramdebug", 0, false},
             {"debug", 0, false},
             {"quick", 0, false},

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -92,6 +92,7 @@ class crunch {
 
     console::message("\nMisc. options:");
     console::printf("-helperThreads # - Set number of helper threads, 0-%d, default=(# of CPU's)-1", cCRNMaxHelperThreads);
+    console::printf("-noTitle - Disable title output at run time");
     console::printf("-noprogress - Disable progress output");
     console::printf("-quiet - Disable all console output");
     console::printf("-ignoreerrors - Continue processing files after errors. Note: The default");
@@ -193,6 +194,7 @@ class crunch {
             {"fileformat", 1, false},
 
             {"helperThreads", 1, false},
+            {"noTitle", 0, false},
             {"noprogress", 0, false},
             {"quiet", 0, false},
             {"ignoreerrors", 0, false},
@@ -1187,7 +1189,8 @@ static int main_internal(int argc, char* argv[]) {
   if (check_for_option(argc, argv, "quiet"))
     console::disable_output();
 
-  print_title();
+  if (!check_for_option(argc, argv, "noTitle"))
+    print_title();
 
   dynamic_string cmd_line;
   get_command_line_as_single_string(cmd_line, argc, argv);

--- a/crunch/crunch.cpp
+++ b/crunch/crunch.cpp
@@ -1158,7 +1158,7 @@ static void print_title() {
   #endif
   console::printf("");
   console::printf("Crunch is brought to you by:");
-  console::printf("- 2014-2023 Daemon Developers and contributors");
+  console::printf("- 2014-2024 Daemon Developers and contributors");
   console::printf("  https://github.com/DaemonEngine/crunch");
   /* Who owns the copyright, Alexander, Unity, both?
   Unity Technologies is a Trade Name for Unity Software Inc. */

--- a/test/test.py
+++ b/test/test.py
@@ -35,7 +35,7 @@ def crunch(input_path, output_path, options=[]):
     if input_path:
         input_path = convert_path(input_path)
         output_path = convert_path(output_path)
-        command_list += ["-file", input_path, "-out", output_path]
+        command_list += ["-noTitle", "-file", input_path, "-out", output_path]
 
     run(command_list)
 


### PR DESCRIPTION
By default crunch prints some information about the software, this is fine for a one-time usage, but a bit noisy when used in bulk calls, like in a test suite.

Also deduplicate option in options list, and bump some date.