### PR TITLE
Make examples multiplatform

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,14 +53,12 @@ strategy:
       APT_PACKAGES: ninja-build g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
       SETUP_COMMANDS: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
       TOOLCHAIN_FILE: cmake/cross-toolchain-mingw64.cmake
-      BUILD_EXAMPLES: ON
       EXE_EXTENSIONS: .exe
     Windows i686 MinGW:
       VM_IMAGE: 'ubuntu-20.04'
       APT_PACKAGES: ninja-build g++-mingw-w64-i686 mingw-w64-i686-dev
       SETUP_COMMANDS: sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
       TOOLCHAIN_FILE: cmake/cross-toolchain-mingw32.cmake
-      BUILD_EXAMPLES: ON
       EXE_EXTENSIONS: .exe
     macOS amd64 AppleClang:
       VM_IMAGE: 'macOS-12'
@@ -107,7 +105,7 @@ steps:
         cmake_args+=(-DCMAKE_CXX_FLAGS="${COMPILER_FLAGS}")
     fi
     if [ -z "${SOURCE_DIR:-}" ]; then
-        cmake_args+=(-DBUILD_CRUNCH=ON -DBUILD_SHARED_LIBCRN=ON -DBUILD_EXAMPLES="${BUILD_EXAMPLES:-OFF}")
+        cmake_args+=(-DBUILD_CRUNCH=ON -DBUILD_SHARED_LIBCRN=ON -DBUILD_EXAMPLES=ON)
     fi
     cmake -S"${SOURCE_DIR:-.}" -Bbuild "${cmake_args[@]}"
     cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ else()
 	endif()
 endif()
 
-if (BUILD_SHARED_LIBCRN OR BUILD_STATIC_LIBCRN OR BUILD_CRUNCH)
+if (BUILD_SHARED_LIBCRN OR BUILD_STATIC_LIBCRN OR BUILD_CRUNCH OR BUILD_EXAMPLES)
+	set_cxx_flag("-pthread")
+	set_linker_flag("-pthread")
 	add_subdirectory(crnlib crnlib)
 endif()
 

--- a/example1/example1.cpp
+++ b/example1/example1.cpp
@@ -3,6 +3,7 @@
 // See Copyright Notice and license at the end of inc/crnlib.h
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <math.h>
 #include <algorithm>
 

--- a/example1/example1.cpp
+++ b/example1/example1.cpp
@@ -7,6 +7,10 @@
 #include <math.h>
 #include <algorithm>
 
+#if !defined(_WIN32)
+#include <libgen.h>
+#endif
+
 // Public crnlib header.
 #include "crnlib.h"
 
@@ -322,9 +326,25 @@ int main(int argc, char* argv[]) {
       return error("Invalid option: %s\n", argv[i]);
   }
 
+  // Split the source filename into its various components.
+#if defined(_WIN32)
   char drive_buf[_MAX_DRIVE], dir_buf[_MAX_DIR], fname_buf[_MAX_FNAME], ext_buf[_MAX_EXT];
   if (_splitpath_s(pSrc_filename, drive_buf, _MAX_DRIVE, dir_buf, _MAX_DIR, fname_buf, _MAX_FNAME, ext_buf, _MAX_EXT))
     return error("Invalid source filename!\n");
+#else
+  char in_filename[FILENAME_MAX];
+  strncpy(in_filename, pSrc_filename, FILENAME_MAX); 
+  const char drive_buf[] = "";
+  char *dir_buf = dirname(in_filename);
+  char *fname_buf = basename(in_filename);
+  char *dot = strrchr(fname_buf, '.');
+  char ext_buf[FILENAME_MAX];
+  ext_buf[0] = '\0';
+  if (dot && dot != fname_buf) {
+    strncpy(ext_buf, dot, strlen(dot));
+    *dot = '\0';
+  }
+#endif
 
   // Load the source file into memory.
   printf("Loading source file: %s\n", pSrc_filename);
@@ -362,8 +382,19 @@ int main(int argc, char* argv[]) {
 
     // If the user has explicitly specified an output file, check the output file's extension to ensure we write the expected format.
     if (out_filename[0]) {
+#if defined(_WIN32)
       char out_fname_buf[_MAX_FNAME], out_ext_buf[_MAX_EXT];
       _splitpath_s(out_filename, NULL, 0, NULL, 0, out_fname_buf, _MAX_FNAME, out_ext_buf, _MAX_EXT);
+#else
+      char *out_fname_buf = basename( in_filename );
+      dot = strrchr(out_fname_buf, '.');
+      char out_ext_buf[FILENAME_MAX];
+	  out_ext_buf[0] = '\0';
+      if (dot && dot != fname_buf) {
+        strncpy(out_ext_buf, dot, strlen(dot));
+        *dot = '\0';
+      }
+#endif
       if (!crnlib_stricmp(out_ext_buf, ".crn"))
         output_crn = true;
       else if (!crnlib_stricmp(out_ext_buf, ".dds"))
@@ -517,8 +548,21 @@ int main(int argc, char* argv[]) {
     crn_free_block(pDDS_file_data);
   } else if (crnlib_stricmp(ext_buf, ".dds") == 0) {
     // Unpack DDS to one or more TGA's.
-    if (out_filename[0])
+    if (out_filename[0]) {
+#if defined(_WIN32)
       _splitpath_s(out_filename, drive_buf, _MAX_DRIVE, dir_buf, _MAX_DIR, fname_buf, _MAX_FNAME, ext_buf, _MAX_EXT);
+#else
+      dir_buf = dirname(out_filename);
+      fname_buf = basename(out_filename);
+      dot = strrchr(fname_buf, '.');
+      ext_buf[FILENAME_MAX];
+	  ext_buf[0] = '\0';
+      if (dot && dot != fname_buf) {
+        strncpy(ext_buf, dot, strlen(dot));
+        *dot = '\0';
+      }
+#endif
+    }
 
     crn_texture_desc tex_desc;
     crn_uint32* pImages[cCRNMaxFaces * cCRNMaxLevels];

--- a/example1/example1.cpp
+++ b/example1/example1.cpp
@@ -27,10 +27,12 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
+#if defined(_WIN32)
 // windows.h is only needed here for GetSystemInfo().
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include "windows.h"
+#endif
 
 using namespace crnlib;
 

--- a/example1/example1.cpp
+++ b/example1/example1.cpp
@@ -303,7 +303,11 @@ int main(int argc, char* argv[]) {
       if (++i >= argc)
         return error("Expected output filename!");
 
+#if defined(_WIN32)
       strcpy_s(out_filename, sizeof(out_filename), argv[i]);
+#else
+      strncpy(out_filename, argv[i], sizeof(out_filename));
+#endif
     } else if (!crnlib_stricmp(argv[i], "-nonsrgb"))
       srgb_colorspace = false;
     else if (!crnlib_stricmp(argv[i], "-nomips"))
@@ -457,7 +461,11 @@ int main(int argc, char* argv[]) {
     char dst_filename[FILENAME_MAX];
     crnlib_snprintf(dst_filename, sizeof(dst_filename), "%s%s%s%s", drive_buf, dir_buf, fname_buf, output_crn ? ".crn" : ".dds");
     if (out_filename[0])
-      strcpy(dst_filename, out_filename);
+#if defined(_WIN32)
+      strcpy_s(dst_filename, sizeof(dst_filename), out_filename);
+#else
+      strncpy(dst_filename, out_filename, sizeof(dst_filename));
+#endif
 
     printf("Writing %s file: %s\n", output_crn ? "CRN" : "DDS", dst_filename);
     FILE* pFile = NULL;
@@ -487,7 +495,11 @@ int main(int argc, char* argv[]) {
     char dst_filename[FILENAME_MAX];
     crnlib_snprintf(dst_filename, sizeof(dst_filename), "%s%s%s.dds", drive_buf, dir_buf, fname_buf);
     if (out_filename[0])
-      strcpy(dst_filename, out_filename);
+#if defined(_WIN32)
+      strcpy_s(dst_filename, sizeof(dst_filename), out_filename);
+#else
+      strncpy(dst_filename, out_filename, sizeof(dst_filename));
+#endif
 
     printf("Writing file: %s\n", dst_filename);
     FILE* pFile = NULL;

--- a/example2/example2.cpp
+++ b/example2/example2.cpp
@@ -12,6 +12,10 @@
 #include <math.h>
 #include <algorithm>
 
+#if !defined(_WIN32)
+#include <libgen.h>
+#endif
+
 // CRN transcoder library.
 #include "crn_decomp.h"
 // .DDS file format definitions.
@@ -96,9 +100,20 @@ int main(int argc, char* argv[]) {
   }
 
   // Split the source filename into its various components.
+#if defined(_WIN32)
   char drive_buf[_MAX_DRIVE], dir_buf[_MAX_DIR], fname_buf[_MAX_FNAME], ext_buf[_MAX_EXT];
   if (_splitpath_s(pSrc_filename, drive_buf, _MAX_DRIVE, dir_buf, _MAX_DIR, fname_buf, _MAX_FNAME, ext_buf, _MAX_EXT))
     return error("Invalid source filename!\n");
+#else
+  char in_filename[FILENAME_MAX];
+  strncpy(in_filename, pSrc_filename, FILENAME_MAX); 
+  const char drive_buf[] = "";
+  char *dir_buf = dirname(in_filename);
+  char *fname_buf = basename(in_filename);
+  char *dot = strrchr(fname_buf, '.');
+  if (dot && dot != fname_buf)
+    *dot = '\0';
+#endif
 
   // Load the source file into memory.
   printf("Loading source file: %s\n", pSrc_filename);

--- a/example2/example2.cpp
+++ b/example2/example2.cpp
@@ -86,7 +86,11 @@ int main(int argc, char* argv[]) {
       if (++i >= argc)
         return error("Expected output filename!");
 
+#if defined(_WIN32)
       strcpy_s(out_filename, sizeof(out_filename), argv[i]);
+#else
+      strncpy(out_filename, argv[i], sizeof(out_filename));
+#endif
     } else
       return error("Invalid option: %s\n", argv[i]);
   }

--- a/example2/timer.cpp
+++ b/example2/timer.cpp
@@ -26,6 +26,7 @@ inline void query_counter_frequency(timer_ticks* pTicks) {
 }
 #elif defined(__GNUC__)
 #include <sys/timex.h>
+#include <sys/time.h>
 inline void query_counter(timer_ticks* pTicks) {
   struct timeval cur_time;
   gettimeofday(&cur_time, NULL);

--- a/example3/example3.cpp
+++ b/example3/example3.cpp
@@ -9,6 +9,10 @@
 #include <math.h>
 #include <algorithm>
 
+#if !defined(_WIN32)
+#include <libgen.h>
+#endif
+
 // CRN transcoder library.
 #include "crnlib.h"
 // .DDS file format definitions.
@@ -132,9 +136,20 @@ int main(int argc, char* argv[]) {
   }
 
   // Split the source filename into its various components.
+#if defined(_WIN32)
   char drive_buf[_MAX_DRIVE], dir_buf[_MAX_DIR], fname_buf[_MAX_FNAME], ext_buf[_MAX_EXT];
   if (_splitpath_s(pSrc_filename, drive_buf, _MAX_DRIVE, dir_buf, _MAX_DIR, fname_buf, _MAX_FNAME, ext_buf, _MAX_EXT))
     return error("Invalid source filename!\n");
+#else
+  char in_filename[FILENAME_MAX];
+  strncpy(in_filename, pSrc_filename, FILENAME_MAX); 
+  const char drive_buf[] = "";
+  char *dir_buf = dirname(in_filename);
+  char *fname_buf = basename(in_filename);
+  char *dot = strrchr(fname_buf, '.');
+  if (dot && dot != fname_buf)
+    *dot = '\0';
+#endif
 
   // Load the source image into memory.
   printf("Loading source file: %s\n", pSrc_filename);

--- a/example3/example3.cpp
+++ b/example3/example3.cpp
@@ -89,7 +89,11 @@ int main(int argc, char* argv[]) {
       if (++i >= argc)
         return error("Expected output filename!");
 
+#if defined(_WIN32)
       strcpy_s(out_filename, sizeof(out_filename), argv[i]);
+#else
+      strncpy(out_filename, argv[i], sizeof(out_filename));
+#endif
     } else if (!crnlib_stricmp(argv[i], "-nonsrgb"))
       srgb_colorspace = false;
     else if (!crnlib_stricmp(argv[i], "-pixelformat")) {
@@ -224,7 +228,11 @@ int main(int argc, char* argv[]) {
   char dst_filename[FILENAME_MAX];
   crnlib_snprintf(dst_filename, sizeof(dst_filename), "%s%s%s.dds", drive_buf, dir_buf, fname_buf);
   if (out_filename[0])
-    strcpy(dst_filename, out_filename);
+#if defined(_WIN32)
+      strcpy_s(dst_filename, sizeof(dst_filename), out_filename);
+#else
+      strncpy(dst_filename, out_filename, sizeof(dst_filename));
+#endif
 
   printf("Writing DDS file: %s\n", dst_filename);
 


### PR DESCRIPTION
Now the examples build everywhere, not only on Windows.

I introduced some `ifdef` that may later be rewritten with deeper change by calling into some already implemented multiplatform functions from crnlib, or to implement such reusable multiplatform function, or to make them reusable, but I expect to do that in a second step, the same way I factorized the snprintf code after having made sure it was right.