### PR TITLE
lzma: do not build an unused function with a dangling pointer warning

### DIFF
--- a/crnlib/lzma_LzmaEnc.cpp
+++ b/crnlib/lzma_LzmaEnc.cpp
@@ -1948,6 +1948,7 @@ const Byte* LzmaEnc_GetCurBuf(CLzmaEncHandle pp) {
   return p->matchFinder.GetPointerToCurrentPos(p->matchFinderObj) - p->additionalOffset;
 }
 
+#if 0 // Unused function producing a dangling-pointer warning.
 SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
                              Byte* dest, size_t* destLen, UInt32 desiredPackSize, UInt32* unpackSize) {
   CLzmaEnc* p = (CLzmaEnc*)pp;
@@ -1980,6 +1981,7 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
 
   return res;
 }
+#endif
 
 SRes LzmaEnc_Encode(CLzmaEncHandle pp, ISeqOutStream* outStream, ISeqInStream* inStream, ICompressProgress* progress,
                     ISzAlloc* alloc, ISzAlloc* allocBig) {


### PR DESCRIPTION
Fixes #70:

- https://github.com/DaemonEngine/crunch/issues/70

I commented it out instead of deleting it, so if one day we want to update lzma the diff will be more meaningful.