### PR TITLE
crnlib: g_number_of_processors is defined on every platform

### DIFF
--- a/crnlib/crn_lzma_codec.cpp
+++ b/crnlib/crn_lzma_codec.cpp
@@ -49,11 +49,7 @@ bool lzma_codec::pack(const void* p, uint n, crnlib::vector<uint8>& buf) {
                               -1, /* 0 <= lp <= 4, default = 0  */
                               -1, /* 0 <= pb <= 4, default = 2  */
                               -1, /* 5 <= fb <= 273, default = 32 */
-#ifdef WIN32
                               (g_number_of_processors > 1) ? 2 : 1
-#else
-                              1
-#endif
                               );
 
       if (status != SZ_ERROR_OUTPUT_EOF)

--- a/crnlib/crn_threading_pthreads.cpp
+++ b/crnlib/crn_threading_pthreads.cpp
@@ -33,8 +33,6 @@ void crn_threading_init() {
   g_number_of_processors = math::maximum<int>(1, sysconf(_SC_NPROCESSORS_ONLN));
 #elif defined(__GNUC__)
   g_number_of_processors = math::maximum<int>(1, get_nprocs());
-#else
-  g_number_of_processors = 1;
 #endif
   g_number_of_processors = math::minimum<int>(g_number_of_processors, task_pool::cMaxThreads);
 }


### PR DESCRIPTION
- g_number_of_processors is defined on every platform
- no need to set default g_number_of_processors to default