### PR TITLE
cmake: disable fast math by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ option(USE_EXTRA_OPTIMIZATION "Enable extra optimization" ON)
 option(USE_LTO "Enable link-time optimization" OFF)
 # Enabling fast math makes generated images less likely to be reproducible.
 # See https://github.com/DaemonEngine/crunch/issues/29
-option(USE_FAST_MATH "Enable fast math (generated images are less likely to be reproducible)" ON)
+option(USE_FAST_MATH "Enable fast math (generated images are less likely to be reproducible)" OFF)
 
 if (MSVC)
 	# Enable MSVC parallel compilation.


### PR DESCRIPTION
Disable fast math by default.

Fast math was initially enabled by default in upstream repository so we inherited that. I noticed that it made the produced images less reproducible, and I added an option to disable fast math, while keeping it enabled by default. I see no performance boost when using fast math so we better favor reproduciblity by default.

Our latest releases were already generated with a crunch built with disabled fast math.

Here are the times when reconverting all images from our `tex-*` packages (`1361` crn files being generated):

build|time
-|-
`-ffast-math -fno-math-errno -ffp-contract=fast`|7m33,276s
`-ffp-contract=off`|7m32,301s
`-ffp-contract=fast`|7m32,208s

I see no reason to sacrifice reproducibility for no other gain in exchange.

I only tested it on Linux with GCC 13 on amd64 architecture, maybe some people may see a difference on other systems, compilers or architectures, so the option to enable fast-math is still kept, but it is not enabled by default.

As far as I know only produced CRN files aren't reproducible with fast math while DDS files are, so maybe that reproducibility difference is a bug, but I don't know how to track it anyway.
