### PR TITLE
crn_decomp: fix non-trivially copyable pointer

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -1456,7 +1456,7 @@ class decoder_tables {
 
     clear();
 
-    memcpy(this, &other, sizeof(*this));
+    memcpy((void*) this, &other, sizeof(*this));
 
     if (other.m_lookup) {
       m_lookup = crnd_new_array<uint32>(m_cur_lookup_size);


### PR DESCRIPTION
Fix #81:

- https://github.com/DaemonEngine/crunch/issues/81

This is the solution recommended by Clang, I don't know if it's correct.