### PR TITLE
crn_decomp: fix: warning: first argument in call to ‘memcpy’ is a pointer to non-trivially copyable type ‘crnd::prefix_coding::decoder_tables’

### DIFF
--- a/inc/crn_decomp.h
+++ b/inc/crn_decomp.h
@@ -1456,7 +1456,7 @@ class decoder_tables {
 
     clear();
 
-    memcpy(this, &other, sizeof(*this));
+    memcpy((void*) this, &other, sizeof(*this));
 
     if (other.m_lookup) {
       m_lookup = crnd_new_array<uint32>(m_cur_lookup_size);


### PR DESCRIPTION
Fix a warning I get when compiling `q3map2`:

```
[ 42%] Building CXX object libs/crnrgba/CMakeFiles/crnrgba.dir/crn_rgba.cpp.o
[ 42%] Linking C static library libpicomodel.a
In file included from netradiant/libs/crnrgba/crn_rgba.cpp:31:
netradiant/libs/crnrgba/../crunch/inc/crn_decomp.h:1459:12: warning: first argument in call to 'memcpy'
 is a pointer to non-trivially copyable type 'crnd::prefix_coding::decoder_tables' [-Wnontrivial-memcall]
 1459 |     memcpy(this, &other, sizeof(*this));
      |            ^
netradiant/libs/crnrgba/../crunch/inc/crn_decomp.h:1459:12: note: explicitly cast the pointer to silence
 this warning
 1459 |     memcpy(this, &other, sizeof(*this));
      |            ^
      |            (void*)
```