### PR TITLE
Fix macOS named-semaphore leak and constructor race

### DIFF
--- a/crnlib/crn_threading_pthreads.cpp
+++ b/crnlib/crn_threading_pthreads.cpp
@@ -3,6 +3,8 @@
 #include "crn_core.h"
 #include "crn_threading_pthreads.h"
 #include "crn_timer.h"
+#include <atomic>
+#include <unistd.h>
 
 #if CRNLIB_USE_PTHREADS_API
 
@@ -104,15 +106,17 @@ semaphore::semaphore(long initialCount, long maximumCount, const char* pName) {
     CRNLIB_FAIL("semaphore: sem_init() failed");
   }
 #else
-  m_name = pName ? pName : "semaphore";
-  for(int i = 0; i < 256; i++) {
-      m_sem = sem_open(m_name, O_CREAT | O_EXCL, 0644, initialCount);
-      if (m_sem != SEM_FAILED)
-      {
-        break;
-      }
-      sem_unlink(m_name);
-  }
+  // Generate a per-instance unique name. The previous code used a fixed
+  // name ("semaphore") for every instance and relied on sem_unlink+retry,
+  // which raced against concurrent constructors using the same name.
+  static std::atomic<unsigned int> s_counter{0};
+  unsigned int idx = s_counter.fetch_add(1u);
+  char buf[64];
+  snprintf(buf, sizeof(buf), "/crn_%d_%u", (int)getpid(), idx);
+  m_name = strdup(buf);
+  (void)pName;
+  sem_unlink(m_name);
+  m_sem = sem_open(m_name, O_CREAT | O_EXCL, 0644, initialCount);
   if (m_sem == SEM_FAILED)
   {
       CRNLIB_FAIL("semaphore: sem_open() failed");
@@ -124,7 +128,9 @@ semaphore::~semaphore() {
 #if !defined(__APPLE__)
   sem_destroy(m_sem);
 #else
+  sem_close(m_sem);
   sem_unlink(m_name);
+  free(const_cast<char*>(m_name));
 #endif
 }
 


### PR DESCRIPTION
## Problem

The macOS branch of `crnlib/crn_threading_pthreads.cpp` has two latent bugs that show up under semaphore-heavy workloads. Found while integrating crunch into a game engine for first-time texture conversion of a level (~hundreds of `ConvertImage` calls back-to-back, each spinning up a fresh `task_pool` with a couple of semaphores).

### Bug 1: destructor leaks each semaphore

```cpp
semaphore::~semaphore() {
#if !defined(__APPLE__)
  sem_destroy(m_sem);
#else
  sem_unlink(m_name);   // removes the name from the kernel namespace
  // ❌ missing: sem_close(m_sem)
#endif
}
```

On macOS (and POSIX more broadly) `sem_unlink()` only removes the name. The semaphore object itself stays alive until the file descriptor returned by `sem_open()` is released by `sem_close()`. So each `~semaphore()` call leaks one FD and one kernel resource. After ~hundreds of `task_pool` create/destroy cycles, `sem_open()` starts failing — observable as `Failure: \"semaphore: sem_open() failed\"`.

### Bug 2: constructor uses a fixed shared name

```cpp
m_name = pName ? pName : "semaphore";
for(int i = 0; i < 256; i++) {
    m_sem = sem_open(m_name, O_CREAT | O_EXCL, 0644, initialCount);
    if (m_sem != SEM_FAILED) break;
    sem_unlink(m_name);
}
```

Every instance constructed without an explicit `pName` uses the literal name `\"semaphore\"`. With `O_CREAT | O_EXCL`, the second concurrent constructor fails the create; the retry loop unlinks and retries, which races with any other thread also constructing a semaphore under the same name.

## Fix

1. Add `sem_close(m_sem)` before `sem_unlink(m_name)` in the destructor.
2. Construct each semaphore with a per-instance unique name `\"/crn_<pid>_<counter>\"`. The 256-retry loop becomes a single `sem_open()` because there is no longer a collision to recover from.

Both changes are macOS-only paths; no behavior change on Linux/other POSIX (where the file uses `sem_init`/`sem_destroy` and never enters the named-semaphore branch).

## Validation

Reliably reproduced the original bug on a macOS 14.8.1 Apple Silicon host running x86_64 crunch under Rosetta — first-time level texture conversion failed at \`crn_threading_pthreads.cpp(118): Failure: \"semaphore: sem_open() failed\"\` after a few dozen conversions. With this patch applied, the same workload runs to completion with hundreds of concurrent semaphore lifecycles.

## Context

This patch ships in [WolfireGames/overgrowth_dev PR #536](https://github.com/WolfireGames/overgrowth_dev/pull/536) where crunch (via this fork) is vendored into the Overgrowth game engine. Sending it upstream so we don't carry a permanent local diff.