### PR TITLE
Some patches to please Debian 💯️

### DIFF
--- a/crnlib/crn_file_utils.cpp
+++ b/crnlib/crn_file_utils.cpp
@@ -347,23 +347,23 @@ bool file_utils::full_path(dynamic_string& path) {
   if (!p)
     return false;
 #else
-  char buf[PATH_MAX];
-  char* p;
+  char* p = nullptr;
   dynamic_string pn, fn;
   split_path(path.get_ptr(), pn, fn);
   if ((fn == ".") || (fn == "..")) {
-    p = realpath(path.get_ptr(), buf);
+    p = realpath(path.get_ptr(), NULL);
     if (!p)
       return false;
-    path.set(buf);
+    path.set(p);
   } else {
     if (pn.is_empty())
       pn = "./";
-    p = realpath(pn.get_ptr(), buf);
+    p = realpath(pn.get_ptr(), NULL);
     if (!p)
       return false;
-    combine_path(path, buf, fn.get_ptr());
+    combine_path(path, p, fn.get_ptr());
   }
+  free(p);
 #endif
 
   return true;

--- a/crnlib/crn_timer.cpp
+++ b/crnlib/crn_timer.cpp
@@ -4,7 +4,7 @@
 #include "crn_timer.h"
 #include <time.h>
 
-#if defined(__FreeBSD__)
+#if !defined(CRNLIB_USE_WIN32_API)
 #include "sys/time.h"
 #endif
 
@@ -27,7 +27,6 @@ inline void query_counter_frequency(timer_ticks* pTicks) {
   QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 }
 #elif defined(__GNUC__)
-#include <sys/timex.h>
 inline void query_counter(timer_ticks* pTicks) {
   struct timeval cur_time;
   gettimeofday(&cur_time, NULL);


### PR DESCRIPTION
The Debian package applies two patches by @twolife:

- https://udd.debian.org/patches.cgi?src=crunch-dxtc&version=0.56.2-1

So we better have the fixes upstream and them not having to apply any patch.

The first patch, I totally rewrote it to be much more generic.
The second patch, I simply added the initialization of `*p` to `nullptr` to the original patch.

I reworded the commit messages in better ways.

For knowledge, the need for those patches were triggered by Debian Hurd… We don't support that, but the actual patches are generic clean-up and improvements that are always good to have. Especially it removes one `ifdef` for FreeBSD and makes the code use a more modern version of `realpath()`.

So in the end the code is in better shape and even has less system-specific branches: more portable with less branches.
